### PR TITLE
use flagstat thread settings in RealignPostProcess

### DIFF
--- a/templates/RealignPostProcess.sh.tt
+++ b/templates/RealignPostProcess.sh.tt
@@ -12,7 +12,7 @@ cd  [% opt.OUTPUT_DIR %]/[% sample %]/tmp
 if [ -s [% opt.OUTPUT_DIR %]/[% sample %]/tmp/[% realignedBam %] ]; then
 	[% INCLUDE Status.tt step=sample status="processing" %]
   
-	[% opt.SAMBAMBA_PATH %]/sambamba flagstat -t [% opt.REALIGNMENT_THREADS %] [% opt.OUTPUT_DIR %]/[% sample %]/tmp/[% realignedBam %] > [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% realignedFlagstat %]
+	[% opt.SAMBAMBA_PATH %]/sambamba flagstat -t [% opt.FLAGSTAT_THREADS %] [% opt.OUTPUT_DIR %]/[% sample %]/tmp/[% realignedBam %] > [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% realignedFlagstat %]
 fi
 
 if [ -s [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% flagstat %]  ] && [ -s [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% realignedFlagstat %] ]; then
@@ -25,12 +25,12 @@ if [ -s [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% flagstat %]  ] && [ -s [% o
         mv [% opt.OUTPUT_DIR %]/[% sample %]/tmp/IndelRealignment.jobreport.txt [% opt.OUTPUT_DIR %]/[% sample %]/logs/IndelRealignment.jobreport.txt
         mv [% opt.OUTPUT_DIR %]/[% sample %]/tmp/IndelRealignment.jobreport.pdf [% opt.OUTPUT_DIR %]/[% sample %]/logs/IndelRealignment.jobreport.pdf
 
-        [% opt.SAMBAMBA_PATH %]/sambamba view -f bam -o [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% cpctSlicedBam %] -L [% opt.PIPELINE_PATH %]/settings/slicing/CPCT_Slicing.bed [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% realignedBam %]
-        [% opt.SAMBAMBA_PATH %]/sambamba index [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% cpctSlicedBam %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% cpctSlicedBamBai %]
+        [% opt.SAMBAMBA_PATH %]/sambamba view -t [% opt.FLAGSTAT_THREADS %] -f bam -o [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% cpctSlicedBam %] -L [% opt.PIPELINE_PATH %]/settings/slicing/CPCT_Slicing.bed [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% realignedBam %]
+        [% opt.SAMBAMBA_PATH %]/sambamba index -t [% opt.FLAGSTAT_THREADS %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% cpctSlicedBam %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% cpctSlicedBamBai %]
 
-        [% opt.SAMBAMBA_PATH %]/sambamba view -f bam -o [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBam %] -L [% opt.PIPELINE_PATH %]/settings/slicing/HealthCheck_Slicing.bed [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% realignedBam %]
-        [% opt.SAMBAMBA_PATH %]/sambamba index [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBam %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBamBai %]
-        [% opt.SAMBAMBA_PATH %]/sambamba flagstat -t [% opt.REALIGNMENT_THREADS %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBam %] > [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedFlagstat %]
+        [% opt.SAMBAMBA_PATH %]/sambamba view -t [% opt.FLAGSTAT_THREADS %] -f bam -o [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBam %] -L [% opt.PIPELINE_PATH %]/settings/slicing/HealthCheck_Slicing.bed [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% realignedBam %]
+        [% opt.SAMBAMBA_PATH %]/sambamba index -t [% opt.FLAGSTAT_THREADS %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBam %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBamBai %]
+        [% opt.SAMBAMBA_PATH %]/sambamba flagstat -t [% opt.FLAGSTAT_THREADS %] [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBam %] > [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedFlagstat %]
 
         [% opt.BAMUTIL_PATH %]/bam diff --in1 [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPostRealignSlicedBam %] --in2 [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPreRealignSlicedBam %] --noPos --onlyDiffs --out [% opt.OUTPUT_DIR %]/[% sample %]/mapping/[% healthCheckPrePostRealignDiff %]
 


### PR DESCRIPTION
The RealignPostProcess script is scheduled using the FLAGSTAT template, so GE will allocate FLAGSTAT_THREADS for this job. This change passes the correct number of allocated threads to the sambamba tasks.