### PR TITLE
Adapt to master version of PyVCF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Cython==0.25.2
-PyVCF==0.6.8
+PyVCF==0.6.9


### PR DESCRIPTION
This tidies up some minor workarounds that are fixed in master PyVCF
at the time of writing. They should be available in the next release,
even if the version change here ends up not being correct (this PR
will fail to pass tests until the release is made/version matches).