### PR TITLE
Adapt pipeline to latest hmftools.

### DIFF
--- a/lib/HMF/Pipeline/SomaticVariants.pm
+++ b/lib/HMF/Pipeline/SomaticVariants.pm
@@ -39,7 +39,7 @@ sub run {
     my ($strelka_job_id, $strelka_vcf) = runStrelka($tumor_sample, $recalibrated_ref_bam, $recalibrated_tumor_bam, $joint_name, $running_jobs, $dirs, $opt);
     push @{$opt->{RUNNING_JOBS}->{somvar}}, $strelka_job_id;
 
-    my $post_process_job_id = postProcessStrelka($joint_name, $final_vcf, $strelka_job_id, $strelka_vcf, $tumor_sample, $dirs, $opt);
+    my $post_process_job_id = postProcessStrelka($joint_name, $final_vcf, $strelka_job_id, $strelka_vcf, $tumor_sample, $recalibrated_tumor_bam, $dirs, $opt);
     push @{$opt->{RUNNING_JOBS}->{somvar}}, $post_process_job_id;
 
     my $done_job_id = markDone($done_file, [ $strelka_job_id, $post_process_job_id ], $dirs, $opt);
@@ -85,7 +85,7 @@ sub runStrelka {
 }
 
 sub postProcessStrelka {
-    my ($joint_name, $final_vcf, $strelka_job_id, $strelka_vcf, $tumor_sample, $dirs, $opt) = @_;
+    my ($joint_name, $final_vcf, $strelka_job_id, $strelka_vcf, $tumor_sample, $tumor_bam_path, $dirs, $opt) = @_;
 
     say "\n### SCHEDULING STRELKA POST PROCESS ###";
 
@@ -98,6 +98,7 @@ sub postProcessStrelka {
         $dirs,
         $opt,
         tumor_sample => $tumor_sample,
+        tumor_bam_path => $tumor_bam_path,
         strelka_vcf => $strelka_vcf,
         final_vcf => $final_vcf,
         joint_name => $joint_name,

--- a/templates/Cobalt.sh.tt
+++ b/templates/Cobalt.sh.tt
@@ -2,13 +2,16 @@
 # -*- TT -*-
 
 [% INCLUDE ErrorHandling.tt %]
-[% INCLUDE Logging.tt job_name="Cobalt" main_step=sample log_name="${opt.RUN_NAME}.log" %]
+[% INCLUDE Logging.tt job_name="Cobalt" main_step=tumor_sample log_name="${opt.RUN_NAME}.log" %]
 
 java -Xmx[% opt.COBALT_MEM %]G \
     -cp "[% opt.COBALT_PATH %]/cobalt.jar" com.hartwig.hmftools.cobalt.CountBamLinesApplication \
-    -input [% sample_bam %] \
-    -sample [% sample %] \
-    -output_dir [% dirs.cobalt %] \
+    -gc_profile "[% opt.GC_PROFILE %]" \
+    -reference "[% ref_sample %]" \
+    -reference_bam "[% ref_bam_path %]" \
+    -tumor "[% tumor_sample %]" \
+    -tumor_bam "[% tumor_bam_path %]" \
+    -output_dir "[% dirs.cobalt %]" \
     -threads [% opt.COBALT_THREADS %]
 
 success

--- a/templates/StrelkaPostProcess.sh.tt
+++ b/templates/StrelkaPostProcess.sh.tt
@@ -16,7 +16,8 @@ java -Xmx[% opt.STRELKAPOSTPROCESS_MEM %]G \
     -v "$input_vcf" \
     -hc_bed "[% opt.HIGH_CONFIDENCE_BED %]" \
     -t "[% tumor_sample %]" \
-    -o "$output_vcf"
+    -o "$output_vcf" \
+    -b "[% tumor_bam_path %]"
 
 assert_not_empty "$output_vcf"
 input_vcf="$output_vcf"


### PR DESCRIPTION
You are certainly already aware that the command-line options for `Cobalt` and `StrelkaPostProcess` have changed in the latest `hmftools`.

These patches update the pipeline to the new versions of `Cobalt` and `StrelkaPostProcess`.
Hopefully this is in line with the design of the pipeline, and hopefully the change is correct.

Thanks for your time,
Roel